### PR TITLE
Avoid vertical scrollbar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,7 @@
 body {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif;
   background-color: #f1f1f1;
+  margin: 0px;
 }
 
 .container {


### PR DESCRIPTION
The website has a tiny vertical scrollbar in Chrome and Firefox right now. This is caused by the `.container` having `height: 100vh` mixed with the implicit margin of the body element.