### PR TITLE
Tweak hardcoded paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,15 @@ RUN npx html-minifier --collapse-whitespace --remove-comments --remove-original-
 FROM alpine:3.17
 
 # Copy binary from build stage
-COPY --from=builder /build/nforwardauth /nforwardauth
+COPY --from=builder /build/nforwardauth /opt/nforwardauth/nforwardauth
 
 # Copy files and assets to serve (overwritable via docker volume mount)
 COPY ./public /public
-COPY --from=minifier /build/style.css /public/style.css
-COPY --from=minifier /build/script.js /public/script.js
-COPY --from=minifier /build/logout.js /public/logout.js
-COPY --from=minifier /build/index.html /public/index.html
-COPY --from=minifier /build/logout.html /public/logout.html
+COPY --from=minifier /build/style.css /opt/nforwardauth/public/style.css
+COPY --from=minifier /build/script.js /opt/nforwardauth/public/script.js
+COPY --from=minifier /build/logout.js /opt/nforwardauth/public/logout.js
+COPY --from=minifier /build/index.html /opt/nforwardauth/public/index.html
+COPY --from=minifier /build/logout.html /opt/nforwardauth/public/logout.html
 
 # Set entrypoint for image
-ENTRYPOINT ["/nforwardauth"]
+ENTRYPOINT ["/opt/nforwardauth/nforwardauth"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,9 @@ static FORWARDED_URI: &str = "X-Forwarded-Uri";
 static FORWARDED_FOR: &str = "X-Forwarded-For";
 
 /* File Paths */
-static INDEX_DOCUMENT: &str = "/public/index.html";
-static LOGOUT_DOCUMENT: &str = "/public/logout.html";
-static PASSWD_FILE: &str = "/passwd";
+static INDEX_DOCUMENT: &str = "/opt/nforwardauth/public/index.html";
+static LOGOUT_DOCUMENT: &str = "/opt/nforwardauth/public/logout.html";
+static PASSWD_FILE: &str = "/opt/nforwardauth/passwd";
 
 /* HTTP Status Responses */
 static NOT_FOUND: &[u8] = b"Not Found";
@@ -54,7 +54,7 @@ async fn api(req: Request<hyper::body::Incoming>) -> Result<Response<BoxBody>> {
         (&Method::GET, "/logout") => api_serve_file(LOGOUT_DOCUMENT, StatusCode::OK).await,
         _ => {
             api_serve_file(
-                format!("/public{}", req.uri().path()).as_str(),
+                format!("/opt/nforwardauth/public{}", req.uri().path()).as_str(),
                 StatusCode::OK,
             )
             .await


### PR DESCRIPTION
This essentially makes it so the app needs to run inside `/opt/nforwardauth`, instead of `/`. 

I wanted to run this fantastic app outside of a Docker container, and this was the quickest solution I could come up with
I know this would be best left to another environment variable, but I don't know enough about Rust yet to figure out passing that down through the web paths. 

The Dockerfile was modified and runs from this new location as well, and seems to be functioning. 

Thanks for the nice and simple application! 