### PR TITLE
`X-Forwarded-User` for downstream identification, rate-limiting for all failed login attempts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # STAGE: Build
-FROM rust:1-alpine3.18 AS builder
+FROM rust:1-alpine3.22 AS builder
 WORKDIR /build
 
 # Install alpine deps

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ services:
     labels:
       - "traefik.http.routers.nforwardauth.rule=Host(`nforwardauth.yourdomain.com`)"
       - "traefik.http.middlewares.nforwardauth.forwardauth.address=http://nforwardauth:3000"
+      - "traefik.http.middlewares.nforwardauth.forwardauth.authResponseHeaders=X-Forwarded-User" #Pass 'X-Forwarded-User' header from response for downstream identification
       - "traefik.http.services.nforwardauth.loadbalancer.server.port=3000"
     volumes:
       - "/path/to/passwd:/passwd:ro" # Mount local passwd file at /passwd as read only
@@ -121,6 +122,7 @@ Look at the `examples` directory in the repository or the below details section 
         - AUTH_HOST=nforwardauth.localhost.com # (required)
         - COOKIE_DOMAIN=localhost.com # Set domain for the cookies. This value will allow cookie and auth on *.yourdomain.com (including base domain)
         - COOKIE_NAME=nforwardauth # Set name for the cookie (helpful if running multiple instances of nforwardauth to prevent collision)
+        - PASS_USER_HEADER=false # Set Whether User is passed in header for downstream identification (default: true, disable to -disallow- username leakage)
         - PORT=3000 # Set specific port to listen on 
       labels:
         - "traefik.http.routers.nforwardauth.rule=Host(`nforwardauth.localhost.com`)"
@@ -150,6 +152,7 @@ Look at the `examples` directory in the repository or the below details section 
 | `COOKIE_DOMAIN` | Set the domain for the cookies, allow auth on sites beyond the root domain | string | Inferred by base url of `AUTH_HOST` | `mydomain.com`
 | `COOKIE_NAME` | Set name for the cookies. Helpful if running multiple instances to prevent collision | string | `nforwardauth` | `auth-token-1`
 | `PORT` | Set port to litsen on | number | `3000` | `80`
+| `PASS_USER_HEADER` | Enable or disable passing of authenticated user in header `X-Forwarded-User` for downstream identification | boolean | `true` | `false`
 | `RATE_LIMITER_ENABLED` | Enable or disable the built-in rate limiter | boolean | `true` | `false`
 | `RATE_LIMITER_MAX_RETRIES` | Max retries allowed within `RATE_LIMITER_FIND_TIME` | integer | `3` | `5`
 | `RATE_LIMITER_FIND_TIME` | Time in seconds to keep track of login attempts | integer | `120` | `60`

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub cookie_secure: bool,
     pub cookie_domain: String,
     pub cookie_name: String,
+    pub pass_user_header: bool,
     pub rate_limiter_enabled: bool,
     pub rate_limiter_max_retries: u32,
     pub rate_limiter_find_time: u32,
@@ -81,6 +82,12 @@ impl Config {
             Err(..) => "nforwardauth".to_string(),
         };
 
+        // pass_user_header: Whether User is passed in header for downstream user identification
+        let pass_user_header: bool = match env::var("PASS_USER_HEADER") {
+            Ok(enabled) => enabled != "false",
+            Err(..) => true,
+        };
+
         // rate_limiter_enabled: Whether rate limiter for logins is enabled or not
         let rate_limiter_enabled: bool = match env::var("RATE_LIMITER_ENABLED") {
             Ok(enabled) => enabled != "false",
@@ -113,6 +120,7 @@ impl Config {
             cookie_secure,
             cookie_domain,
             cookie_name,
+            pass_user_header,
             rate_limiter_enabled,
             rate_limiter_max_retries,
             rate_limiter_find_time,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -41,9 +41,9 @@ impl RateLimiter {
             .expect("Failed to initialize rate limiter");
     }
 
-    pub fn try_login(&mut self, ip: IpAddr) -> bool {
+    pub fn is_banned(&mut self, ip: IpAddr) -> bool {
         let now = Instant::now();
-
+        //initialize attempt
         let attempt = self.attempts.entry(ip).or_insert(Attempt {
             retries: 0,
             first_attempt_time: now,
@@ -52,7 +52,7 @@ impl RateLimiter {
 
         if let Some(banned_until) = attempt.banned_until {
             if now < banned_until {
-                return false;
+                return true;
             } else {
                 // Unban if the ban time has elapsed
                 attempt.banned_until = None;
@@ -60,6 +60,18 @@ impl RateLimiter {
                 attempt.first_attempt_time = now;
             }
         }
+
+        false
+    }
+    
+    pub fn record_failed_attempt(&mut self, ip: IpAddr) {
+        let now = Instant::now();
+        // initialize attempt (though should be there due to is_banned)
+        let attempt = self.attempts.entry(ip).or_insert(Attempt {
+            retries: 0,
+            first_attempt_time: now,
+            banned_until: None,
+        });
 
         if now.duration_since(attempt.first_attempt_time) > self.find_time {
             // Reset the counter and time if outside the find_time window
@@ -70,12 +82,7 @@ impl RateLimiter {
         attempt.retries += 1;
 
         if attempt.retries > self.max_retries {
-            // Ban for ban_time duration
             attempt.banned_until = Some(now + self.ban_time);
-            return false;
         }
-
-        // Not rate limited, return true
-        true
     }
 }


### PR DESCRIPTION
Thanks for [nforwardauth ](https://github.com/nosduco/nforwardauth)- great tool for simple and fast authentication without setting up complicated authentication infrastructure. 

**TLDR:** added `X-Forwarded-User`

A while ago I noticed `X-Forwarded-User` header was missing for downstream identification and patched it into the code for a scenario where the username (multi-user) is necessary in downstream app.

Now I finally took the time to properly include the changes and stumbled upon few minor issues which I improved along the way.

### Improvements included:

1. added ` X-Forwarded-User` for downstream identification - widely used method for user authentication in proxy scenarios (example: Grafana), this massivle expands usage area👍🏻
2. improved rate limiter: added failed basic auth attempts to reduce brute-forcability
2.1 validated `X-Forwarded-For` parsing against standard (rl should work behind multiple proxies)
3. improved response for auth inquiries from proxy by not sending full logout-page all the time
5. bumped alpine (for building)
6. minor cleanup and details

Thanks again, great tool.

